### PR TITLE
different implementation which can be used to do rescursion

### DIFF
--- a/create_grid.cu
+++ b/create_grid.cu
@@ -21,6 +21,14 @@ struct Grid {
 		: bottom_left(bl), bottom_right(br), top_left(tl), top_right(tr) {}
 };
 
+// NODE:
+struct Node {
+	int x_min, x_max, y_min, y_max;
+	int start_idx;
+	int end_idx;
+	Node *bl, *br, *ul, *ur;
+};
+
 __global__ void categorize_points(Point *d_points, int *d_categories,
 								  int *grid_counts, int count, int range,
 								  int middle) {
@@ -121,6 +129,78 @@ __global__ void organize_points(Point *d_points, int *d_categories, Point *bl,
 		}
 	}
 }
+
+// ---------- UTIL FUNCTIONS ---------------------
+
+__global__ void assignBuckets(Point* points, int* bucketCounts, int* sortedIndices, 
+                              float xMin, float xRange, float yMin, float yRange, int numPoints) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx < numPoints) {
+        Point p = points[idx];
+        int xIndex = 2 * (p.x - xMin) / xRange;
+        int yIndex = 2 * (p.y - yMin) / yRange;
+        int bucketIndex = 2 * yIndex + xIndex;
+        
+        // Atomic add to bucket counts for each bucket
+        atomicAdd(&bucketCounts[bucketIndex], 1);
+
+        // Save the bucket index for sorting later
+        sortedIndices[idx] = bucketIndex;
+    }
+}
+
+__global__ void reorderPoints(Point* points, Point* sortedPoints, int* sortedIndices, int numPoints) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx < numPoints) {
+        int bucket = sortedIndices[idx];
+        int position = atomicAdd(&bucketPositions[bucket], 1);  // Position within the sorted bucket
+        sortedPoints[position] = points[idx];
+    }
+}
+
+__global__ void findMinMax(Point* points, float* xMin, float* xMax, float* yMin, float* yMax, int n) {
+    //dynamic shared memory: holding min and max of the block, used for further reduction
+	extern __shared__ float sharedMinMax[];
+
+    int tid = threadIdx.x;
+    int idx = blockIdx.x * blockDim.x + tid;
+
+    // Initialize local variables for min and max
+    float localXMin = (idx < n) ? x[idx] : FLT_MAX;
+    float localXMax = (idx < n) ? x[idx] : -FLT_MAX;
+    float localYMin = (idx < n) ? y[idx] : FLT_MAX;
+    float localYMax = (idx < n) ? y[idx] : -FLT_MAX;
+
+	// Store local mins and maxes in shared memory
+    sharedMinMax[tid] = localXMin;                  
+    sharedMinMax[blockDim.x + tid] = localXMax;
+    sharedMinMax[2 * blockDim.x + tid] = localYMin;
+    sharedMinMax[3 * blockDim.x + tid] = localYMax;
+
+    __syncthreads();
+
+    // Performing reduction in shared memory to find min and max for each block
+    for (int s = blockDim.x / 2; s > 0; s = s/2) {
+        if (tid < s) {
+            sharedMinMax[tid] = fminf(sharedMinMax[tid], sharedMinMax[tid + s]);            // Reduce x min
+            sharedMinMax[blockDim.x + tid] = fmaxf(sharedMinMax[blockDim.x + tid], sharedMinMax[blockDim.x + tid + s]); // Reduce x max
+            sharedMinMax[2 * blockDim.x + tid] = fminf(sharedMinMax[2 * blockDim.x + tid], sharedMinMax[2 * blockDim.x + tid + s]); // Reduce y min
+            sharedMinMax[3 * blockDim.x + tid] = fmaxf(sharedMinMax[3 * blockDim.x + tid], sharedMinMax[3 * blockDim.x + tid + s]); // Reduce y max
+        }
+        __syncthreads();
+    }
+
+    // Once we reach this point we will have each block's min and max so we write the result for min/max of all blocks to global memory
+    if (tid == 0) {
+        atomicMin(xMin, sharedMinMax[0]);
+        atomicMax(xMax, sharedMinMax[blockDim.x]);
+        atomicMin(yMin, sharedMinMax[2 * blockDim.x]);
+        atomicMax(yMax, sharedMinMax[3 * blockDim.x]);
+    }
+}
+
+// -------------------------------
+
 
 void quadtree_grid(vector<Point> points, int count, int dimension) {
 	// Array of points for the geospatial data


### PR DESCRIPTION
This is a rough draft of utilities. Have a look at this. This seems easy as we keep sorting each node as we go level by level. That was at level n, we'll have all in a sorted array like:  ([NW, NE, SW, SE], [NW, NE, SW, SE], [NW, NE, SW, SE].....). We'll have random say 10,000 data points. 

**driver func()**{
**We first Initialize the Root Node**:
1. Start by creating a root Node that represents the entire dataset.
2. Set x_min, x_max, y_min, and y_max to the bounding box values found in the findMinMax kernel.
3. Set start_idx and end_idx to cover the entire range of data points.
4. Initially, set bl, br, ul, and ur to nullptr (indicating it has no children yet).

**Then we subdivide parent Node to quads**:

If the node’s data range exceeds a certain threshold (which is a feature of quadtree itself I guess), split the node into four child nodes by:
1. Compute the midpoint of the node’s bounding box: x_mid = (x_min + x_max) / 2 and y_mid = (y_min + y_max) / 2.
2. Create four new Node instances, each representing one quadrant:
  Bottom-left: x_min to x_mid, y_min to y_mid
  Bottom-right: x_mid to x_max, y_min to y_mid
  Upper-left: x_min to x_mid, y_mid to y_max
  Upper-right: x_mid to x_max, y_mid to y_max
3. Assign data points to each child node based on whether they fall within the child node’s bounding box:
  Here, we will use assignBuckets() and reorderPoints() kernels [in PR] to split points to children and then once that's done:
  
**Create Child Nodes like how we did with parent node**:
  
  With the points now sorted by quadrant, you can create the four child nodes.
  Set each child node’s bounding box and data range:
  For example, start_idx and end_idx for the BL child will cover the contiguous range of points assigned to the BL quadrant in the reordered array.
  Initialize the bl, br, ul, and ur pointers in the parent node to point to these new child nodes._ 

}**Driver func end (use a recursive loop here)**


